### PR TITLE
Elastika panel: make it the same width, not height, as Tube Unit.

### DIFF
--- a/src/elastika/editor.cpp
+++ b/src/elastika/editor.cpp
@@ -84,7 +84,7 @@ ElastikaEditor::ElastikaEditor(shared::audioToUIQueue_t &atou, shared::uiToAudio
     stif_slider = shared::makeSlider(this, modcode, "stif_slider");
     shared::bindSlider(this, stif_slider, patchCopy.stiffness);
 
-    setSize(368, 600);
+    setSize(286, 466);
     resized();
 
     idleTimer = std::make_unique<IdleTimer>(*this);


### PR DESCRIPTION
The Elastika panel looked weird next to the Tube Unit panel because its text was larger.

I made them both have consistent text size by making Elastika the same width as Tube Unit, not the same height. This works because both have the same HP width in VCV Rack.

Made Elastika shorter than Tube Unit to preserve the correct aspect ratio.

![dawsapphire](https://github.com/user-attachments/assets/68792ae9-891a-470b-8a51-031b7aeddc1e)
