### PR TITLE
Automatically determine panel dimensions from Sapphire.

### DIFF
--- a/src/elastika/editor.cpp
+++ b/src/elastika/editor.cpp
@@ -77,7 +77,8 @@ ElastikaEditor::ElastikaEditor(shared::audioToUIQueue_t &atou, shared::uiToAudio
     stif_slider = shared::makeSlider(this, modcode, "stif_slider");
     shared::bindSlider(this, stif_slider, patchCopy.stiffness);
 
-    setSize(286, 466);
+    auto dim = shared::getPanelDimensions(modcode);
+    setSize(dim.width, dim.height);
     resized();
 
     idleTimer = std::make_unique<shared::IdleTimer<ElastikaEditor>>(*this);

--- a/src/galaxy/editor.cpp
+++ b/src/galaxy/editor.cpp
@@ -48,26 +48,25 @@ GalaxyEditor::GalaxyEditor(shared::audioToUIQueue_t &atou, shared::uiToAudioQueu
         }
     }
 
-    // FIXFIXFIX: text labels live inside Galaxy_labels.svg.
-    // FIXFIXFIX: "vent" lives inside Galaxy_vent.svg.
-    // FIXFIXFIX: "seal" lives inside Galaxy_seal.svg.
+    const std::string modcode("galaxy");
 
-    replace = shared::makeLargeKnob(this, "galaxy", "replace_knob");
+    replace = shared::makeLargeKnob(this, modcode, "replace_knob");
     shared::bindSlider(this, replace, patchCopy.replace);
 
-    brightness = shared::makeLargeKnob(this, "galaxy", "brightness_knob");
+    brightness = shared::makeLargeKnob(this, modcode, "brightness_knob");
     shared::bindSlider(this, brightness, patchCopy.brightness);
 
-    detune = shared::makeLargeKnob(this, "galaxy", "detune_knob");
+    detune = shared::makeLargeKnob(this, modcode, "detune_knob");
     shared::bindSlider(this, detune, patchCopy.detune);
 
-    bigness = shared::makeLargeKnob(this, "galaxy", "bigness_knob");
+    bigness = shared::makeLargeKnob(this, modcode, "bigness_knob");
     shared::bindSlider(this, bigness, patchCopy.bigness);
 
-    mix = shared::makeLargeKnob(this, "galaxy", "mix_knob");
+    mix = shared::makeLargeKnob(this, modcode, "mix_knob");
     shared::bindSlider(this, mix, patchCopy.mix);
 
-    setSize(286, 600);
+    auto dim = shared::getPanelDimensions(modcode);
+    setSize(dim.width, dim.height);
     resized();
 
     idleTimer = std::make_unique<shared::IdleTimer<GalaxyEditor>>(*this);

--- a/src/gravy/editor.cpp
+++ b/src/gravy/editor.cpp
@@ -64,14 +64,13 @@ GravyEditor::GravyEditor(shared::audioToUIQueue_t &atou, shared::uiToAudioQueue_
         }
     }
 
-    // FIXFIXFIX: text labels live inside tubeunit_labels.svg.
-    // FIXFIXFIX: "vent" lives inside tubeunit_vent.svg.
-    // FIXFIXFIX: "seal" lives inside tubeunit_seal.svg.
+    const std::string modcode("gravy");
 
-    airflow = shared::makeLargeKnob(this, "gravy", "frequency_knob");
+    airflow = shared::makeLargeKnob(this, modcode, "frequency_knob");
     shared::bindSlider(this, airflow, patchCopy.frequency);
 
-    setSize(286, 600);
+    auto dim = shared::getPanelDimensions(modcode);
+    setSize(dim.width, dim.height);
     resized();
 
     idleTimer = std::make_unique<shared::IdleTimer<GravyEditor>>(*this);

--- a/src/shared/graphics_resources.cpp
+++ b/src/shared/graphics_resources.cpp
@@ -43,4 +43,16 @@ std::optional<std::string> getSvgForPath(const std::string &path)
     ;
 }
 
+PanelDimensions getPanelDimensions(const std::string& modcode)
+{
+    // Get panel dimensions in VCV Rack millimeter units.
+    auto mmPanel = Sapphire::GetPanelDimensions(modcode);
+
+    // Convert millimeters to pixels.
+    const float pixelsPerMillimeter = 286 / 60.96;
+    int dx = static_cast<int>(std::round(pixelsPerMillimeter * mmPanel.cx));
+    int dy = static_cast<int>(std::round(pixelsPerMillimeter * mmPanel.cy));
+    return PanelDimensions(dx, dy);
+}
+
 } // namespace sapphire_plugins::shared

--- a/src/shared/graphics_resources.h
+++ b/src/shared/graphics_resources.h
@@ -15,12 +15,27 @@
 #ifndef SAPPHIRE_PLUGINS_SHARED_GRAPHICS_RESOURCES_H
 #define SAPPHIRE_PLUGINS_SHARED_GRAPHICS_RESOURCES_H
 
+#include <cmath>
 #include <optional>
 #include <string>
+#include "sapphire_panel.hpp"
 
 namespace sapphire_plugins::shared
 {
 std::optional<std::string> getSvgForPath(const std::string &path);
+
+struct PanelDimensions
+{
+    int width;
+    int height;
+
+    explicit PanelDimensions(int _width, int _height)
+        : width(_width)
+        , height(_height)
+        {}
+};
+
+PanelDimensions getPanelDimensions(const std::string& modcode);
 }
 
 #endif // GRAPHICS_RESOURCES_H

--- a/src/tube_unit/editor.cpp
+++ b/src/tube_unit/editor.cpp
@@ -48,38 +48,37 @@ TubeUnitEditor::TubeUnitEditor(shared::audioToUIQueue_t &atou, shared::uiToAudio
         }
     }
 
-    // FIXFIXFIX: text labels live inside tubeunit_labels.svg.
-    // FIXFIXFIX: "vent" lives inside tubeunit_vent.svg.
-    // FIXFIXFIX: "seal" lives inside tubeunit_seal.svg.
+    const std::string modcode("tubeunit");
 
-    airflow = shared::makeLargeKnob(this, "tubeunit", "airflow_knob");
+    airflow = shared::makeLargeKnob(this, modcode, "airflow_knob");
     shared::bindSlider(this, airflow, patchCopy.airflow);
 
-    vortex = shared::makeLargeKnob(this, "tubeunit", "vortex_knob");
+    vortex = shared::makeLargeKnob(this, modcode, "vortex_knob");
     shared::bindSlider(this, vortex, patchCopy.vortex);
 
-    width = shared::makeLargeKnob(this, "tubeunit", "width_knob");
+    width = shared::makeLargeKnob(this, modcode, "width_knob");
     shared::bindSlider(this, width, patchCopy.width);
 
-    center = shared::makeLargeKnob(this, "tubeunit", "center_knob");
+    center = shared::makeLargeKnob(this, modcode, "center_knob");
     shared::bindSlider(this, center, patchCopy.center);
 
-    decay = shared::makeLargeKnob(this, "tubeunit", "decay_knob");
+    decay = shared::makeLargeKnob(this, modcode, "decay_knob");
     shared::bindSlider(this, decay, patchCopy.decay);
 
-    angle = shared::makeLargeKnob(this, "tubeunit", "angle_knob");
+    angle = shared::makeLargeKnob(this, modcode, "angle_knob");
     shared::bindSlider(this, angle, patchCopy.angle);
 
-    root = shared::makeLargeKnob(this, "tubeunit", "root_knob");
+    root = shared::makeLargeKnob(this, modcode, "root_knob");
     shared::bindSlider(this, root, patchCopy.root);
 
-    spring = shared::makeLargeKnob(this, "tubeunit", "spring_knob");
+    spring = shared::makeLargeKnob(this, modcode, "spring_knob");
     shared::bindSlider(this, spring, patchCopy.spring);
 
-    outputLevel = shared::makeLargeKnob(this, "tubeunit", "level_knob");
+    outputLevel = shared::makeLargeKnob(this, modcode, "level_knob");
     shared::bindSlider(this, outputLevel, patchCopy.outputLevel);
 
-    setSize(286, 600);
+    auto dim = shared::getPanelDimensions(modcode);
+    setSize(dim.width, dim.height);
     resized();
 
     idleTimer = std::make_unique<shared::IdleTimer<TubeUnitEditor>>(*this);


### PR DESCRIPTION
Now there is a "_panel" pseudo-component under each module code in sapphire_panel.cpp.
Exploit this to automatically determine the window sizes for each plugin.