### PR TITLE
Tube Unit panel: better alignment of knobs and labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@ To build
 git clone https://github.com/baconpaul/sapphire-plugins
 cd sapphire-plugins
 git submodule update --init --recursive
-cmake -Bignore/bld -DCMAKE_BUILD_TYPE=Release  
+cmake -Bignore/bld -DCMAKE_BUILD_TYPE=Release
 cmake --build ignore/bld --target sapphire-plugins_all
 ```
 
-If you don't want to copy the built plugins (mac/lin) after build do 
+If you don't want to copy the built plugins (mac/lin) after build do
 
 ```
 cmake -Bignore/bld -DCMAKE_BUILD_TYPE=Release -DCOPY_AFTER_BUILD=FALSE
 ```
 
-and then install the resulting artifact by hand. 
+and then install the resulting artifact by hand.
 
-Right now has
+The following Sapphire modules are included:
 
 - Elastika
+- Galaxy
+- Gravy
 - Tube Unit

--- a/src/shared/graphics_resources.cpp
+++ b/src/shared/graphics_resources.cpp
@@ -49,7 +49,7 @@ PanelDimensions getPanelDimensions(const std::string& modcode)
     auto mmPanel = Sapphire::GetPanelDimensions(modcode);
 
     // Convert millimeters to pixels.
-    const float pixelsPerMillimeter = 286 / 60.96;
+    const float pixelsPerMillimeter = 600 / 128.5;
     int dx = static_cast<int>(std::round(pixelsPerMillimeter * mmPanel.cx));
     int dy = static_cast<int>(std::round(pixelsPerMillimeter * mmPanel.cy));
     return PanelDimensions(dx, dy);

--- a/src/tube_unit/editor.cpp
+++ b/src/tube_unit/editor.cpp
@@ -48,7 +48,7 @@ TubeUnitEditor::TubeUnitEditor(shared::audioToUIQueue_t &atou, shared::uiToAudio
         }
     }
 
-    const std::string modcode("tubeunit");
+    const std::string modcode("tubeunit_export");
 
     airflow = shared::makeLargeKnob(this, modcode, "airflow_knob");
     shared::bindSlider(this, airflow, patchCopy.airflow);


### PR DESCRIPTION
The panels are looking better, but still not quite right. There are variable gaps of black above and below each panel. The gaps are larger for the thinner panels for Galaxy and Gravy.

![dawsapphire](https://github.com/user-attachments/assets/578940f1-0b8d-41d1-8c7c-14f58d53d8f4)
