### PR TITLE
Default Airflow to 0 in TubeUnit

### DIFF
--- a/src/tube_unit/patch.h
+++ b/src/tube_unit/patch.h
@@ -58,7 +58,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                        .withName("Airflow")
                                                        .withID(100)
                                                        .withRange(0, 5)
-                                                       .withDefault(1)
+                                                       .withDefault(0)
                                                        .withLinearScaleFormatting("")),
           vortex(floatMd().withName("Vortex").withID(110).asPercent().withDefault(0.5)),
           width(floatMd()


### PR DESCRIPTION
This stops the effect from self-oscillating when dragged into an empty channel strip by default, which is a pretty daw unfriendly behavior

Closes #26